### PR TITLE
Refine revert detection and add agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository Guidelines for Agents
+
+All code changes should:
+- pass syntax checks: `python3 -m py_compile contropedia.py`
+- run a sample invocation: `python3 contropedia.py "Python (programming language)" | head -n 4`
+
+Please mention these steps in PR summaries.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The script outputs the total revision count, detected revert count, and a simple
 
 ## Web Interface
 
-You can also launch a small Flask web application to try the analysis in your browser:
+You can also launch a small Flask web application to try the analysis in your browser. The page now uses a simple card layout and styled form controls for a cleaner look:
 
 ```bash
 pip install Flask

--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ python3 contropedia.py "Article Title"
 ```
 
 The script outputs the total revision count, detected revert count, and a simple controversy score.
+
+## Web Interface
+
+You can also launch a small Flask web application to try the analysis in your browser:
+
+```bash
+pip install Flask
+python3 web_app.py
+```
+
+Then open `http://127.0.0.1:5000/` and enter an article title.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 This repository recreates a simplified version of **Contropedia**, a tool for analyzing controversies in Wikipedia. The original project is described on [contropedia.net](https://contropedia.net) as an "analysis and visualization of controversies within Wikipedia articles".
 
-The included script fetches revision data from the Wikipedia API and computes a basic controversy score based on revert activity in edit summaries. It is inspired by the paper *Contropedia - the analysis and visualization of controversies in Wikipedia articles* (Borra et al., CHI 2015, DOI [10.1145/2641580.2641622](https://doi.org/10.1145/2641580.2641622)).
+The included script fetches revision data from the Wikipedia API and computes
+a basic controversy score based on detected revert activity. A revision is
+considered a revert when the edit summary mentions reverting or when its SHA1
+hash matches a previous revision, indicating content restoration. The tool is
+inspired by the paper *Contropedia - the analysis and visualization of controversies in Wikipedia articles* (Borra et al., CHI 2015, DOI [10.1145/2641580.2641622](https://doi.org/10.1145/2641580.2641622)).
 
 ## Usage
 

--- a/web_app.py
+++ b/web_app.py
@@ -10,12 +10,53 @@ HTML_TEMPLATE = """
     <meta charset="utf-8">
     <title>Contropedia Lite</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 2em; }
-        form { margin-bottom: 1em; }
-        .result { background: #f0f0f0; padding: 1em; border-radius: 5px; }
+        body {
+            font-family: system-ui, sans-serif;
+            background: #f6f8fa;
+            display: flex;
+            justify-content: center;
+            padding: 2em;
+        }
+        .container {
+            background: #fff;
+            padding: 2em 3em;
+            border-radius: 8px;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+            width: 28em;
+        }
+        form {
+            display: flex;
+            gap: 0.5em;
+            margin-bottom: 1em;
+        }
+        input[type=text] {
+            flex: 1;
+            padding: 0.5em;
+            font-size: 1em;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        button {
+            padding: 0.5em 1em;
+            border: none;
+            background: #007bff;
+            color: white;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover {
+            background: #0056b3;
+        }
+        .result {
+            margin-top: 1em;
+            background: #f0f8ff;
+            padding: 1em;
+            border-radius: 5px;
+        }
     </style>
 </head>
 <body>
+<div class="container">
     <h1>Contropedia Lite</h1>
     <form method="get">
         <input type="text" name="title" placeholder="Article title" value="{{ title }}">
@@ -29,6 +70,7 @@ HTML_TEMPLATE = """
         <p><strong>Controversy score:</strong> {{ result.score }}</p>
     </div>
     {% endif %}
+</div>
 </body>
 </html>
 """

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,55 @@
+from flask import Flask, render_template_string, request
+from contropedia import fetch_revisions, analyze_reverts
+
+app = Flask(__name__)
+
+HTML_TEMPLATE = """
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Contropedia Lite</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        form { margin-bottom: 1em; }
+        .result { background: #f0f0f0; padding: 1em; border-radius: 5px; }
+    </style>
+</head>
+<body>
+    <h1>Contropedia Lite</h1>
+    <form method="get">
+        <input type="text" name="title" placeholder="Article title" value="{{ title }}">
+        <button type="submit">Analyze</button>
+    </form>
+    {% if result %}
+    <div class="result">
+        <p><strong>Article:</strong> {{ title }}</p>
+        <p><strong>Total revisions fetched:</strong> {{ result.total }}</p>
+        <p><strong>Detected reverts:</strong> {{ result.reverts }}</p>
+        <p><strong>Controversy score:</strong> {{ result.score }}</p>
+    </div>
+    {% endif %}
+</body>
+</html>
+"""
+
+class Result:
+    def __init__(self, total, reverts, score):
+        self.total = total
+        self.reverts = reverts
+        self.score = score
+
+@app.route('/', methods=['GET'])
+def index():
+    title = request.args.get('title', '')
+    result = None
+    if title:
+        revisions = fetch_revisions(title)
+        total = len(revisions)
+        reverts = analyze_reverts(revisions)
+        score = round(reverts / total, 3) if total else 0
+        result = Result(total, reverts, score)
+    return render_template_string(HTML_TEMPLATE, title=title, result=result)
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- clarify SHA1-based revert detection in README
- add helper `is_hash_revert` in `contropedia.py`
- create AGENTS.md outlining repository checks

## Testing
- `python3 -m py_compile contropedia.py`
- `python3 contropedia.py "Python (programming language)" | head -n 4`


------
https://chatgpt.com/codex/tasks/task_e_685a00ea2fc083338425397b651aab4e